### PR TITLE
Fix opt segfaults in function declarations

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -262,6 +262,7 @@ void AggressiveDCEPass::AddBreaksAndContinuesToWorklist(
 }
 
 bool AggressiveDCEPass::AggressiveDCE(Function* func) {
+  if (func->IsDeclaration()) return false;
   std::list<BasicBlock*> structured_order;
   cfg()->ComputeStructuredOrder(func, &*func->begin(), &structured_order);
   live_local_vars_.clear();

--- a/source/opt/mem_pass.cpp
+++ b/source/opt/mem_pass.cpp
@@ -413,6 +413,7 @@ void MemPass::RemoveBlock(Function::iterator* bi) {
 }
 
 bool MemPass::RemoveUnreachableBlocks(Function* func) {
+  if (func->IsDeclaration()) return false;
   bool modified = false;
 
   // Mark reachable all blocks reachable from the function's entry block.


### PR DESCRIPTION
Check if a function is a declaration without any blocks before doing optimizations on the function blocks.