### PR TITLE
Fix for op image sample footprint nv

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -421,6 +421,7 @@ bool spvOpcodeIsLoad(const spv::Op opcode) {
     case spv::Op::OpImageSampleProjExplicitLod:
     case spv::Op::OpImageSampleProjDrefImplicitLod:
     case spv::Op::OpImageSampleProjDrefExplicitLod:
+    case spv::Op::OpImageSampleFootprintNV:
     case spv::Op::OpImageFetch:
     case spv::Op::OpImageGather:
     case spv::Op::OpImageDrefGather:
@@ -747,6 +748,7 @@ bool spvOpcodeIsImageSample(const spv::Op opcode) {
     case spv::Op::OpImageSparseSampleExplicitLod:
     case spv::Op::OpImageSparseSampleDrefImplicitLod:
     case spv::Op::OpImageSparseSampleDrefExplicitLod:
+    case spv::Op::OpImageSampleFootprintNV:
       return true;
     default:
       return false;

--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -994,6 +994,7 @@ bool IsAllowedSampledImageOperand(spv::Op opcode, ValidationState_t& _) {
     case spv::Op::OpImageBlockMatchWindowSSDQCOM:
     case spv::Op::OpImageBlockMatchGatherSADQCOM:
     case spv::Op::OpImageBlockMatchGatherSSDQCOM:
+    case spv::Op::OpImageSampleFootprintNV:
       return true;
     case spv::Op::OpStore:
       if (_.HasCapability(spv::Capability::BindlessTextureNV)) return true;


### PR DESCRIPTION
This fixes a validation error described in an issue, https://github.com/shader-slang/slang/issues/5830

The real fix should be merged on the KhronosGroup/SPIRV-Tools.
https://github.com/KhronosGroup/SPIRV-Tools/pull/5914

But it will take some time for them to review and merge.
We need this fix as soon as possible.